### PR TITLE
Cause server launch to listen and react to server state changes

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviour.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviour.java
@@ -25,15 +25,21 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * A {@link ServerBehaviourDelegate} for App Engine Server executed via the Java App Management
  * Client Library.
  */
 public class LocalAppEngineServerBehaviour extends ServerBehaviourDelegate {
+  private static final Logger logger =
+      Logger.getLogger(LocalAppEngineServerBehaviour.class.getName());
+
   private LocalAppEngineStartListener localAppEngineStartListener;
   private LocalAppEngineExitListener localAppEngineExitListener;
   private AppEngineDevServer devServer;
+  private Process devProcess;
 
   public LocalAppEngineServerBehaviour () {
     localAppEngineStartListener = new LocalAppEngineStartListener();
@@ -42,9 +48,31 @@ public class LocalAppEngineServerBehaviour extends ServerBehaviourDelegate {
 
   @Override
   public void stop(boolean force) {
-    setServerState(IServer.STATE_STOPPING);
-    terminate();
-    setServerState(IServer.STATE_STOPPED);    
+    int serverState = getServer().getServerState();
+    if (serverState == IServer.STATE_STOPPED) {
+      return;
+    }
+    // If the server seems to be running, and we haven't already tried to stop it,
+    // then try to shut it down nicely
+    if (devServer != null && (!force || serverState != IServer.STATE_STOPPING)) {
+      setServerState(IServer.STATE_STOPPING);
+      // TODO: when available configure the host and port specified in the server
+      DefaultStopConfiguration stopConfig = new DefaultStopConfiguration();
+      try {
+        devServer.stop(stopConfig);
+      } catch (AppEngineException ex) {
+        logger.log(Level.WARNING, "Error terminating server: " + ex.getMessage(), ex);
+      }
+    } else {
+      // we've already given it a chance
+      logger.info("forced stop: destroying associated processes");
+      if (devProcess != null) {
+        devProcess.destroy();
+        devProcess = null;
+      }
+      devServer = null;
+      setServerState(IServer.STATE_STOPPED);
+    }
   }
 
   /**
@@ -179,27 +207,16 @@ public class LocalAppEngineServerBehaviour extends ServerBehaviourDelegate {
     devServer = new CloudSdkAppEngineDevServer(cloudSdk);
   }
 
-  private void terminate() {
-    if (devServer != null) {
-      // TODO: when available configure the host and port specified in the server
-      DefaultStopConfiguration stopConfig = new DefaultStopConfiguration();
-      try {
-        devServer.stop(stopConfig);
-      } catch (AppEngineException ex) {
-        // TODO what do we need to do here
-        Activator.logError("Error terminating server: " + ex.getMessage());
-      }
-      devServer = null;
-    }
-  }
-
   /**
    * A {@link ProcessExitListener} for the App Engine server.
    */
   public class LocalAppEngineExitListener implements ProcessExitListener {
     @Override
     public void onExit(int exitCode) {
-      stop(true);
+      logger.log(Level.FINE, "Process exit: code=" + exitCode);
+      devServer = null;
+      devProcess = null;
+      setServerState(IServer.STATE_STOPPED);
     }
   }
 
@@ -209,6 +226,8 @@ public class LocalAppEngineServerBehaviour extends ServerBehaviourDelegate {
   public class LocalAppEngineStartListener implements ProcessStartListener {
     @Override
     public void onStart(Process process) {
+      logger.log(Level.FINE, "New Process: " + process);
+      devProcess = process;
       setServerState(IServer.STATE_STARTED);
     }
   }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
@@ -28,6 +28,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchManager;
@@ -67,20 +68,21 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
   private static final String DEBUGGER_HOST = "localhost";
 
   @Override
-  public void launch(ILaunchConfiguration configuration, String mode, ILaunch launch,
+  public void launch(ILaunchConfiguration configuration, String mode, final ILaunch launch,
       IProgressMonitor monitor) throws CoreException {
     AnalyticsPingManager.getInstance().sendPing(AnalyticsEvents.APP_ENGINE_LOCAL_SERVER,
         AnalyticsEvents.APP_ENGINE_LOCAL_SERVER_MODE, mode);
 
     IServer server = ServerUtil.getServer(configuration);
     if (server == null) {
-      return;
+      String message = "There is no App Engine development server available";
+      Status status = new Status(IStatus.ERROR, Activator.PLUGIN_ID, message);
+      throw new CoreException(status);
     }
     IModule[] modules = server.getModules();
     if (modules == null || modules.length == 0) {
       return;
     }
-
     // App Engine dev server can only debug one module at a time
     // as we cannot configure the IVMConnector to continue listening
     if (mode.equals(ILaunchManager.DEBUG_MODE) && modules.length > 1) {
@@ -109,7 +111,20 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
         server.addServerListener(new OpenBrowserListener(pageLocation));
       }
     }
-
+    // If the server is stopped, then terminate any ancillary processes
+    server.addServerListener(new IServerListener() {
+      @Override
+      public void serverChanged(ServerEvent event) {
+        if (event.getState() == IServer.STATE_STOPPED) {
+          event.getServer().removeServerListener(this);
+          try {
+            launch.terminate();
+          } catch (DebugException ex) {
+            logger.log(Level.WARNING, "Unable to terminate launch", ex);
+          }
+        }
+      }
+    });
     if (ILaunchManager.DEBUG_MODE.equals(mode)) {
       int debugPort = getDebugPort();
       setupDebugTarget(launch, configuration, debugPort, monitor);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LocalAppEngineConsolePageParticipant.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LocalAppEngineConsolePageParticipant.java
@@ -1,5 +1,7 @@
 package com.google.cloud.tools.eclipse.appengine.localserver.ui;
 
+import com.google.cloud.tools.eclipse.appengine.localserver.server.LocalAppEngineServerBehaviour;
+
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IToolBarManager;
@@ -8,10 +10,9 @@ import org.eclipse.ui.console.IConsole;
 import org.eclipse.ui.console.IConsoleConstants;
 import org.eclipse.ui.console.IConsolePageParticipant;
 import org.eclipse.ui.part.IPageBookViewPage;
+import org.eclipse.wst.server.core.IServer;
 import org.eclipse.wst.server.ui.internal.ImageResource;
 import org.eclipse.wst.server.ui.internal.Messages;
-
-import com.google.cloud.tools.eclipse.appengine.localserver.server.LocalAppEngineServerBehaviour;
 
 /**
  * Adds a stop button for the App Engine runtime to the {@link LocalAppEngineConsole}
@@ -57,7 +58,9 @@ public class LocalAppEngineConsolePageParticipant implements IConsolePagePartici
         //code to execute when button is pressed
         LocalAppEngineServerBehaviour serverBehaviour = console.getServerBehaviourDelegate();
         if (serverBehaviour != null) {
-          serverBehaviour.stop(true);
+          // try to initiate a nice shutdown
+          boolean force = serverBehaviour.getServer().getServerState() == IServer.STATE_STOPPING;
+          serverBehaviour.stop(force);
         }
         update();
       }


### PR DESCRIPTION
Cause server launch to listen and react to server state changes such that stopping the server terminates the launch.

_Note:_ this only clears up the _Debug_ situation; #614 will fix the _Run_ situation

Also cleaned up server stopping to set state to STOPPED once the server process is reported as dead.  This was to fix strange race condition where the server could be reported as STOPPED but continued to write to the console.

Fixes #516