### PR TITLE
Fix bug: Set max module instance = 1 in *debug* mode, not in *run* mode

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviour.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviour.java
@@ -138,10 +138,6 @@ public class LocalAppEngineServerBehaviour extends ServerBehaviourDelegate {
     DefaultRunConfiguration devServerRunConfiguration = new DefaultRunConfiguration();
     devServerRunConfiguration.setAppYamls(runnables);
 
-    // todo: make this a configurable option, but default to
-    // 1 instance to simplify debugging
-    devServerRunConfiguration.setMaxModuleInstances(1);
-
     // FIXME: workaround bug when running on a Java8 JVM
     // https://github.com/GoogleCloudPlatform/gcloud-eclipse-tools/issues/181
     devServerRunConfiguration.setJvmFlags(Arrays.asList("-Dappengine.user.timezone=UTC"));
@@ -171,6 +167,10 @@ public class LocalAppEngineServerBehaviour extends ServerBehaviourDelegate {
     // Create run configuration
     DefaultRunConfiguration devServerRunConfiguration = new DefaultRunConfiguration();
     devServerRunConfiguration.setAppYamls(runnables);
+
+    // todo: make this a configurable option, but default to
+    // 1 instance to simplify debugging
+    devServerRunConfiguration.setMaxModuleInstances(1);
 
     List<String> jvmFlags = new ArrayList<String>();
     // FIXME: workaround bug when running on a Java8 JVM


### PR DESCRIPTION
In c0e409b1946d92bc5975cc28eb9e6127c225ecca, I mistakenly restored the call to `DefaultRunConfiguration.setMaxModuleInstances(1)` to the _run_ server setup instead of the _debug_ server setup.