### PR TITLE
Improve SERVER_STARTED detection

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
@@ -180,8 +180,6 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
    */
   private class OpenBrowserListener implements IServerListener {
     private String pageLocation;
-    // todo[issue #556]: must wait a fixed time in case the server is subsequently stopped
-    private int waitTime = 1500;// ms
 
     public OpenBrowserListener(String pageLocation) {
       this.pageLocation = pageLocation;
@@ -219,7 +217,7 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
           return Status.OK_STATUS;
         }
       };
-      openJob.schedule(waitTime);
+      openJob.schedule();
       server.removeServerListener(this);
     }
   }


### PR DESCRIPTION
Scan the `dev_appserver` output for special strings to identify the server start or failure state as per #556.

Fixes #556 