### PR TITLE
remove import to let the Messages class in the same package to be used

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployConsolePageParticipant.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployConsolePageParticipant.java
@@ -18,7 +18,6 @@ import org.eclipse.ui.console.IConsolePageParticipant;
 import org.eclipse.ui.part.IPageBookViewPage;
 
 import com.google.cloud.tools.eclipse.appengine.deploy.standard.StandardDeployJob;
-import com.google.cloud.tools.eclipse.ui.util.Messages;
 import com.google.common.base.Preconditions;
 
 public class DeployConsolePageParticipant implements IConsolePageParticipant {


### PR DESCRIPTION
After experimenting with DeployConsolePageParticipant the import for the Messages class was not cleaned up and thus the tooltips for the action buttons were missing.