### PR TITLE
Cut travis log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jdk:
 install: 
   # download Cloud SDK
   - wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-125.0.0-linux-x86_64.tar.gz
-  - tar -xzvf google-cloud-sdk-125.0.0-linux-x86_64.tar.gz
+  - tar -xzf google-cloud-sdk-125.0.0-linux-x86_64.tar.gz
   # update all Cloud SDK components
   - gcloud components update --quiet
   # add App Engine component to Cloud SDK


### PR DESCRIPTION
Untar generates about 5300 log lines. This will cut more than half of the entire log. With this, I expect we won't see the "This log is too long to be displayed." issue (#628).

![selection_012](https://cloud.githubusercontent.com/assets/10523105/18689318/862fdc50-7f56-11e6-92db-0cfe8188025f.png)

![selection_013](https://cloud.githubusercontent.com/assets/10523105/18689371/cab1a994-7f56-11e6-9fec-e756a0c6197e.png)